### PR TITLE
current_date.sh

### DIFF
--- a/.github/workflows/binary.yaml
+++ b/.github/workflows/binary.yaml
@@ -24,6 +24,11 @@ jobs:
       - name: Setup Arduino CLI
         uses: arduino/setup-arduino-cli@v2
 
+      - name: date into header
+        working-directory: firmware
+        run: |
+          ./current_date.sh
+
       # see also 0-setup.bat
       - name: Install platform
         run: |

--- a/firmware/build_info.h
+++ b/firmware/build_info.h
@@ -1,1 +1,1 @@
-#define DASH_TAG "dev"
+#define DASH_TAG "2025-08-03"

--- a/firmware/current_date.sh
+++ b/firmware/current_date.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+# This script generates a C header file 'build_info.h'
+# which contains the current date as a build tag.
+
+BUILD_INFO_FILE="build_info.h"
+
+# Get the current date in YYYY-MM-DD format
+# You can change the format string below if you prefer a different date format.
+# For example, to get 'YYYY-MM-DD-HH-MM', use `date +'%Y-%m-%d-%H-%M'`.
+CURRENT_DATE=$(date +'%Y-%m-%d')
+
+# The `DASH_TAG` will be the current date enclosed in double quotes.
+DASH_TAG_VALUE="\"${CURRENT_DATE}\""
+
+# Write the #define statement to the file.
+# The 'DASH_TAG' will be defined with the current date string.
+echo "#define DASH_TAG ${DASH_TAG_VALUE}" > "${BUILD_INFO_FILE}"
+
+# Print a confirmation message to the console.
+echo "Created '${BUILD_INFO_FILE}' with DASH_TAG set to: ${DASH_TAG_VALUE}"


### PR DESCRIPTION
fun fact: bash script was produced by gemini

```
i have one line C header

#define DASH_TAG "dev"

make a bash script which would create that build_info.h file with current date instead of "dev"
```
